### PR TITLE
Setup deployment to GitHub Releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 *.exe
 *.app
 *.tar.gz
+
+# package artifacts
+pkg/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: bash
+
 sudo: false
+
 install: true
+
 addons:
   apt:
     packages:
@@ -8,13 +11,40 @@ addons:
     - luarocks
 
 before_install:
-  - luarocks install --local lpeg
-  - "`luarocks path`" # set PATH to include local tree
+- luarocks install --local lpeg
+- "`luarocks path`"
 
-script:
-  - find src -iname "*.lua" | xargs luac -p
+jobs:
+  include:
+  - stage: build
+    script:
+    - find src -iname "*.lua" | xargs luac -p
+  - stage: package
+    script: 
+    - echo "Creating LÖVE packages ..."
+    - "./package.sh src love"
+    - "./package.sh src linux"
+    - "./package.sh src macos"
+    - "./package.sh src windows"
+
+stages:
+- build
+- name: package
+  if: tag IS present
 
 notifications:
   email:
     on_success: never
     on_failure: change
+
+deploy:
+  provider: releases
+  api_key:
+    secure: UwQeea/uAVaQfpjIeYOK98SzFeJt2YlR7CIdov2HhY0brfHzRSBui5KrpPIga/Q0Df6rUOE3uMLWqKSqD6iLOk8gygFN5TKpxFecUeO6RcMdxmwg33VWMkNmJ7QGE6kxF4383aekY/8PGRdvK8bAwS473u48gNpi7meglw+DvUGpmDxt5jZdH3puqsazDQxj3DM1SepZkEQXuPLBepUHDbKTkFtDOZ4mUiwQ9dQ34If/WBnmPKK1Jlanbr931CdFJXixNzDFBrncq3ETIU7vcH+0pJBcXqDpWbFP7o/CtfvHhVbIrCpaXfxmYIpubqo9rbocnp3S+2xa4295lVKc+4lagoqWBYkk0GTiMEKI7Iuq/pRDxBmZTDlUPWU4D5tTJbbjLvvYqyvR2OiFpbIor3D4O21ixXjdCtcnz+f3YRWcQMVhoKvatAnMc1n4SxUKMyFBmU5yfbseUNf45oU5IjhLus7sGJ84BODPRdaf7nHIeCRNqCd7+ZOlHmHOo1D3eY87M59qh7Kbeo4UsBT2aP7H3R0b+eaZw6LL/SCWh+4QE7hipqvItpu3qOs8iQXtIJPSSBcYOs4YdtgEo+auyj+lljUzvLMhAPTXgVBVxQ7I08BHB6m7LJHYzdybWujklH1H/2viHcL5iJ4WsCgkbBKDsEr1kcGKvXgu7+SUMVM=
+  file:
+  - "pkg/FollowMe.love"
+  - "pkg/FollowMe.zip"
+  - "pkg/FollowMe.exe"
+  skip_cleanup: true
+  on:
+    tags: true

--- a/Info.plist
+++ b/Info.plist
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildMachineOSBuild</key>
+	<string>17D47</string>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleDocumentTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeExtensions</key>
+			<array>
+				<string>love</string>
+			</array>
+			<key>CFBundleTypeIconFile</key>
+			<string>GameIcon</string>
+			<key>CFBundleTypeName</key>
+			<string>LÖVE Project</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Owner</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>org.love2d.love-game</string>
+			</array>
+			<key>LSTypeIsPackage</key>
+			<integer>1</integer>
+		</dict>
+		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Folder</string>
+			<key>CFBundleTypeOSTypes</key>
+			<array>
+				<string>fold</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>None</string>
+		</dict>
+		<dict>
+			<key>CFBundleTypeIconFile</key>
+			<string>Document</string>
+			<key>CFBundleTypeName</key>
+			<string>Document</string>
+			<key>CFBundleTypeOSTypes</key>
+			<array>
+				<string>****</string>
+			</array>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+		</dict>
+	</array>
+	<key>CFBundleExecutable</key>
+	<string>love</string>
+	<key>CFBundleIconFile</key>
+	<string>OS X AppIcon</string>
+	<key>CFBundleIconName</key>
+	<string>OS X AppIcon</string>
+	<key>CFBundleIdentifier</key>
+	<string>org.BinaryReveries.FollowMe</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>FollowMe</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>11.1</string>
+	<key>CFBundleSignature</key>
+	<string>LoVe</string>
+	<key>CFBundleSupportedPlatforms</key>
+	<array>
+		<string>MacOSX</string>
+	</array>
+	<key>DTCompiler</key>
+	<string>com.apple.compilers.llvm.clang.1_0</string>
+	<key>DTPlatformBuild</key>
+	<string>9C40b</string>
+	<key>DTPlatformVersion</key>
+	<string>GM</string>
+	<key>DTSDKBuild</key>
+	<string>17C76</string>
+	<key>DTSDKName</key>
+	<string>macosx10.13</string>
+	<key>DTXcode</key>
+	<string>0920</string>
+	<key>DTXcodeBuild</key>
+	<string>9C40b</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.games</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string>© 2006-2018 LÖVE Development Team</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<false/>
+</dict>
+</plist>

--- a/package.sh
+++ b/package.sh
@@ -1,0 +1,77 @@
+#! /bin/bash
+#
+# Name:
+#   package.sh - creates a new LOVE release for a given OS target
+#
+# Synopsis:
+#   package.sh SRC TARGET
+#
+# Description:
+#   package.sh creates a new LOVE package from a given SRC for a given OS
+#   TARGET. Valid targets: macos, windows, and linux.
+#
+
+# exit if attempting to use unset variable
+set -o nounset
+
+# exit if any statement returns a false value
+set -o errexit
+
+PKG="./pkg"
+LOVE_MACOS_URL="https://bitbucket.org/rude/love/downloads/love-11.1-macos.zip"
+LOVE_WIN_URL="https://bitbucket.org/rude/love/downloads/love-11.1-win32.zip"
+USAGE="Usage: deploy.sh SRC TARGET\n"
+
+if [ "$#" -lt 1 -o "$#" -gt 2 ]
+  then
+    printf "$USAGE"
+    exit 1
+fi
+
+if [ -z "$1" ]
+  then
+    printf "Invalid SRC: %s\n" $1
+    printf "$USAGE"
+    exit 1
+fi
+
+SRC="$1"
+TARGET="$2"
+
+
+case "$TARGET" in
+  "love")
+    printf "Creating LÖVE package ... %s.\n"
+    pushd "$SRC" && zip -r FollowMe.love . && popd
+    mkdir -p "$PKG" && mv -v "$SRC/FollowMe.love" $PKG
+    ;;
+  "macos")
+    printf "Creating macOS app bundle ...\n"
+    cp -v Info.plist "$PKG"
+    pushd "$PKG"
+    curl -L -o love-macos.zip "$LOVE_MACOS_URL"
+    unzip love-macos.zip
+    mv -v love.app FollowMe.app
+    cp -v FollowMe.love "FollowMe.app/Contents/Resources/"
+    cp -v Info.plist "FollowMe.app/Contents/"
+    zip -r FollowMe.zip FollowMe.app
+    rm -rf Info.plist love-macos.zip FollowMe.app
+    popd
+    ;;
+  "windows")
+    printf "Creating Windows executable ...\n"
+    pushd "$PKG"
+    curl -L -o love.exe "$LOVE_WIN_URL"
+    cat love.exe FollowMe.love > FollowMe.exe
+    rm -rf love.exe
+    popd
+    ;;
+  "linux")
+    pushd "$PKG"
+    # currently the easiest way to distribute to linux is to ship the love
+    # package and ask users to install LÖVE, so this is a NOP for now
+    printf "Creating Linux package ...\n"
+    popd
+    ;;
+  *) printf "Invalid target: %s.\n" "$TARGET" && exit 1;;
+esac

--- a/src/conf.lua
+++ b/src/conf.lua
@@ -1,0 +1,4 @@
+function love.conf(t)
+  t.version = "11.0"
+  t.window.title = "FollowMe"
+end


### PR DESCRIPTION
Add `package.sh` which creates the creates a new LÖVE package from a
given source directory and target OS.

Rename existing portion of Travis pipeline into `build` stage. Add new
`package` stage which only executes upon creation of tags. This stage
then invokes `package.sh` for each of our current targets (Linux, macOS,
and Linux). `Info.plist` is used with the macOS target to configure the
app bundle. Upon completion of these stages, the platform specific
artifacts are uploaded to GitHub.

Add `conf.lua` which informs LÖVE the minimum version the game is
compatible with as well as setting the title of the window.