### PR TITLE
Unzip Windows package before concatenating binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Windows packaging procedure to unzip LÖVE before `cat`ing with game package.
 
 ## [0.2.4] - 2018-10-01
 ### Added

--- a/package.sh
+++ b/package.sh
@@ -61,9 +61,11 @@ case "$TARGET" in
   "windows")
     printf "Creating Windows executable ...\n"
     pushd "$PKG"
-    curl -L -o love.exe "$LOVE_WIN_URL"
+    curl -L -o love-win.zip "$LOVE_WIN_URL"
+    unzip -j love-win.zip -d love-win
+    mv -v love-win/love.exe .
     cat love.exe FollowMe.love > FollowMe.exe
-    rm -rf love.exe
+    rm -rf love.exe love-win love-win.zip
     popd
     ;;
   "linux")


### PR DESCRIPTION
Resolve bug in package script which rendered the Windows version of the
game useless. Windows package is now unzipped before being concatenated
with the game package.

Clean up intermediate build files related to Windows upon completion of
package construction.