### PR TITLE
Remove Green Tint From Player Sprite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Make road based on player position and angle.
 
+### Changed
+- Draw ordering to ensure player sprite is not color of bounding box.
+
 ## [0.2.5] - 2018-10-02
 ### Changed
 - Windows packaging procedure to unzip LÖVE before `cat`ing with game package.

--- a/src/main.lua
+++ b/src/main.lua
@@ -230,10 +230,6 @@ function love.draw()
   distText = string.format(distance)
   love.graphics.print(distText, objects.frontier.body:getX() + 20, objects.frontier.body:getY() + 20)
     
-  
-  love.graphics.setColor(0.28, 0.64, 0.05)
-  love.graphics.polygon("line",
-    player.body:getWorldPoints(player.shape:getPoints()))
   love.graphics.draw(player.img,
                      player.body:getX(),
                      player.body:getY(),
@@ -243,6 +239,9 @@ function love.draw()
                      player.width/2,
                      player.height/2)
 
+  love.graphics.setColor(0.28, 0.64, 0.05)
+  love.graphics.polygon("line",
+    player.body:getWorldPoints(player.shape:getPoints()))
   speedText = string.format("%d m/s", player.speed)
 
   love.graphics.print(speedText, player.body:getX()+14, player.body:getY()-10)


### PR DESCRIPTION
Resolve issue causing player sprites to appear with a green tint by
re-ordering the drawing calls. Specifically the player collision lines
and speed are draw after the sprite to avoid calling `setColor` more
than necessary.

Resolves: #7 