### PR TITLE
Add basic scrolling camera

### DIFF
--- a/src/entities/camera.lua
+++ b/src/entities/camera.lua
@@ -1,0 +1,47 @@
+local camera = {}
+
+function camera:load()
+  self.x = 0
+  self.y = 0
+  self.scaleX = 1
+  self.scaleY = 1
+  self.rotation = 0
+end
+
+function camera:set()
+  love.graphics.push()
+  love.graphics.rotate(-self.rotation)
+  love.graphics.scale(1 / self.scaleX, 1 / self.scaleY)
+  love.graphics.translate(-self.x, -self.y)
+end
+
+function camera:unset()
+  love.graphics.pop()
+end
+
+function camera:move(dx, dy)
+  self.x = self.x + (dx or 0)
+  self.y = self.y + (dy or 0)
+end
+
+function camera:rotate(dr)
+  self.rotation = self.rotation + dr
+end
+
+function camera:scale(sx, sy)
+  sx = sx or 1
+  self.scaleX = self.scaleX * sx
+  self.scaleY = self.scaleY * (sy or sx)
+end
+
+function camera:setPosition(x, y)
+  self.x = x or self.x
+  self.y = y or self.y
+end
+
+function camera:setScale(sx, sy)
+  self.scaleX = sx or self.scaleX
+  self.scaleY = sy or self.scaleY
+end
+
+return camera

--- a/src/main.lua
+++ b/src/main.lua
@@ -6,6 +6,7 @@ world = nil
 local assets = nil
 local block1 = nil
 local border = nil
+local camera = nil
 local ground = nil
 local height = 650
 local player = nil
@@ -17,6 +18,10 @@ function love.load()
   assets = require "assets" -- load assets
   love.physics.setMeter(16) -- length of a meter in our world is 16px
   world = love.physics.newWorld(0, 0, true) -- create a world with no horizontal or vertical gravity
+
+  -- create camera
+  camera = require "entities/camera"
+  camera:load()
 
   -- create ground
   ground = require "entities/ground"
@@ -71,6 +76,8 @@ function love.update(dt)
     world:update(dt) -- put the world in motion!
   end
 
+  camera:move(player.dx, player.dy)
+
   player:update(ground, dt)
 
   -- detect if player is triggering new road creation and calculate location of new road
@@ -94,6 +101,8 @@ function love.update(dt)
 end
 
 function love.draw()
+  camera:set()
+
   ground:draw()
   love.graphics.setColor(0.28, 0.64, 0.05)
   love.graphics.polygon("fill",
@@ -107,6 +116,8 @@ function love.draw()
   road:draw()
 
   player:draw()
+
+  camera:unset()
 end
 
 function love.filedropped(file)


### PR DESCRIPTION
Implement `camera` entity using the transformation stack functionality
of LÖVE. Currently we are not drawing the ground past the initial
location so the `border` and `ground` entities do not render past the
edge of the initial viewport.