### PR TITLE
logger: shorten function names

### DIFF
--- a/src/argparse/argparse.lua
+++ b/src/argparse/argparse.lua
@@ -18,7 +18,7 @@ function argparse:parse(raw)
     for i=1,#raw do
       if raw[i] == '--' .. option then
         if i + 1 > #raw then
-          logger:log_fatal("argument '%s' is missing value", raw[i])
+          logger:fatal("argument '%s' is missing value", raw[i])
         end
         args[option] = raw[i + 1]
         return

--- a/src/logger/logger.lua
+++ b/src/logger/logger.lua
@@ -1,17 +1,17 @@
 local logger = {}
 
-function logger:log(msg, ...)
+function logger:info(msg, ...)
   print(string.format(msg, ...))
 end
 
-function logger:log_debug(msg, ...)
+function logger:debug(msg, ...)
   if not debug_enabled then
     return
   end
   print(string.format(msg, ...))
 end
 
-function logger:log_fatal(msg, ...)
+function logger:fatal(msg, ...)
   error(string.format(msg, ...))
 end
 

--- a/src/main.lua
+++ b/src/main.lua
@@ -19,9 +19,9 @@ local width = 650
 function love.load(args)
   args = argparse:parse(args)
   debug_enabled = args['debug']
-  logger:log_debug("debug mode enabled")
+  logger:debug("debug mode enabled")
   for k, v in pairs(args) do
-    logger:log_debug("\t%s -> %s", k, v)
+    logger:debug("\t%s -> %s", k, v)
   end
 
   love.physics.setMeter(16) -- length of a meter in our world is 16px


### PR DESCRIPTION
Encourage a little less typing.  Also, I misspelled one. =p