### PR TITLE
implement global gamectx module

### DIFF
--- a/src/argparse/argparse.lua
+++ b/src/argparse/argparse.lua
@@ -1,26 +1,25 @@
+local ctx = require("gamectx/global")
 local logger = require("logger/logger")
 
 local argparse = {}
 
-function argparse:parse(raw)
-  local args = {}
-
-  function parse_flag(flag)
-    for i=1,#raw do
-      if raw[i] == '--' .. flag then
-        args[flag] = true
+function argparse:parse(args)
+  local function parse_flag(flag)
+    for i=1,#args do
+      if args[i] == '--' .. flag then
+        ctx:set_arg(flag, true)
         return
       end
     end
   end
 
-  function parse_value(option)
-    for i=1,#raw do
-      if raw[i] == '--' .. option then
-        if i + 1 > #raw then
-          logger:fatal("argument '%s' is missing value", raw[i])
+  local function parse_value(option)
+    for i=1,#args do
+      if args[i] == '--' .. option then
+        if i + 1 > #args then
+          logger:fatal("argument '%s' is missing value", args[i])
         end
-        args[option] = raw[i + 1]
+        ctx:set_arg(option, args[i + 1])
         return
       end
     end
@@ -28,8 +27,6 @@ function argparse:parse(raw)
 
   parse_flag('debug')
   parse_value('connect')
-
-  return args
 end
 
 return argparse

--- a/src/gamectx/global.lua
+++ b/src/gamectx/global.lua
@@ -1,0 +1,37 @@
+local GLOBAL_CTX_MANAGER_CODE = "gamectx/global_manager.lua"
+
+local ctx = {}
+
+local GLOBAL_CTX_REQ_CHAN = 'ctx_req'
+local req_chan = love.thread.getChannel(GLOBAL_CTX_REQ_CHAN)
+local resp_chan = love.thread.newChannel()
+
+function ctx:set(key, val)
+  req_chan:push({action='set', key=key, val=val})
+end
+
+function ctx:get(key)
+  req_chan:push({action='get', key=key, resp_chan=resp_chan})
+  return resp_chan:demand()
+end
+
+function ctx:set_arg(key, val)
+  req_chan:push({action='set_arg', key=key, val=val})
+end
+
+function ctx:get_arg(key)
+  req_chan:push({action='get_arg', key=key, resp_chan=resp_chan})
+  return resp_chan:demand()
+end
+
+function ctx:get_args()
+  req_chan:push({action='get_args', resp_chan=resp_chan})
+  return resp_chan:demand()
+end
+
+function ctx:load()
+  local t = love.thread.newThread(GLOBAL_CTX_MANAGER_CODE)
+  t:start(req_chan)
+end
+
+return ctx

--- a/src/gamectx/global_manager.lua
+++ b/src/gamectx/global_manager.lua
@@ -1,0 +1,36 @@
+local ctx = require("gamectx/global")
+local logger = require("logger/logger")
+local req_chan = ...
+
+local args = { -- populated by argparse
+  debug=nil,
+  connect=nil,
+}
+
+local opts = {
+  debug_enabled=false,
+}
+
+local function arg_to_opt(key, val)
+  if key == 'debug' then
+    opts.debug_enabled = true
+  end
+end
+
+while true do
+  local data = req_chan:demand()
+  if data.action == 'set' then
+    opts[data.key] = data.val
+  elseif data.action == 'get' then
+    data.resp_chan:push(opts[data.key])
+  elseif data.action == 'set_arg' then
+    args[data.key] = data.val
+    arg_to_opt(data.key, data.val)
+  elseif data.action == 'get_arg' then
+    data.resp_chan:push(args[data.key])
+  elseif data.action == 'get_args' then
+    data.resp_chan:push(args)
+  else
+    logger:fatal("unrecognized action: %s", data.action)
+  end
+end

--- a/src/logger/logger.lua
+++ b/src/logger/logger.lua
@@ -1,3 +1,5 @@
+local ctx = require("gamectx/global")
+
 local logger = {}
 
 function logger:info(msg, ...)
@@ -5,7 +7,7 @@ function logger:info(msg, ...)
 end
 
 function logger:debug(msg, ...)
-  if not debug_enabled then
+  if not ctx:get('debug_enabled') then
     return
   end
   print(string.format(msg, ...))

--- a/src/main.lua
+++ b/src/main.lua
@@ -1,15 +1,14 @@
 -- FollowMe
 -- Move car around using the arrow keys.
--- Compatible with löve 0.10.0 and up
 local argparse = require("argparse/argparse")
 local assets = require("assets")
 local camera = require("entities/camera")
+local ctx = require('gamectx/global')
 local ground = require("entities/ground")
 local logger = require("logger/logger")
 local player = require("entities/player")
 local road = require("entities/road")
 
-debug_enabled = false
 world = nil
 local block1 = nil
 local border = nil
@@ -17,10 +16,10 @@ local height = 650
 local width = 650
 
 function love.load(args)
-  args = argparse:parse(args)
-  debug_enabled = args['debug']
+  ctx:load()
+  argparse:parse(args)
   logger:debug("debug mode enabled")
-  for k, v in pairs(args) do
+  for k, v in pairs(ctx:get_args()) do
     logger:debug("\t%s -> %s", k, v)
   end
 


### PR DESCRIPTION
Also known as ctx, the global gamectx module provides a mechanism for
accessing game state in a way that can be safely shared across all
threads in the game.

The global gamectx starts a thread on load().  This thread is
responsible for storing and serializing all access to the global
gamectx's state.  Access to the state is granted via the request
channel.

To request state, a query and response channel are passed through the
request channel.  Once the management thread has processed the request,
it will send the result through the provided response channel, as if it
were a callback.  Updating state is achieved in much the same way, but a
response channel is not currently used.

The global gamectx interface handles all the channel coordination.