### PR TITLE
Decouple input from update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Decouple keyboard controls from `player:update`.
 
 ## [0.3.1] - 2019-02-09
 ### Added

--- a/src/entities/player.lua
+++ b/src/entities/player.lua
@@ -60,21 +60,32 @@ function player:update(ground, dt)
 
   angle = self.body:getAngle()
   mass = self.body:getMass()
-  if love.keyboard.isDown("w") then
-    if love.keyboard.isDown("a") then
-      self.body:applyTorque(-self.turnMultiplier * inertia)
-    elseif love.keyboard.isDown("d") then
-      self.body:applyTorque(self.turnMultiplier * inertia)
-    end
+  if self.isaccelerating then
     fx = mass * -self.acceleration * math.cos(angle)
     fy = mass * -self.acceleration * math.sin(angle)
     self.body:applyForce(fx, fy)
-  elseif love.keyboard.isDown("s") then
-    if love.keyboard.isDown("a") then
+  end
+
+  if self.isbraking then
+  end
+
+  if self.isturningleft then
+    if self.isreversing then
       self.body:applyTorque(self.turnMultiplier * inertia)
-    elseif love.keyboard.isDown("d") then
+    else
       self.body:applyTorque(-self.turnMultiplier * inertia)
     end
+  end
+
+  if self.isturningright then
+    if self.isreversing then
+      self.body:applyTorque(-self.turnMultiplier * inertia)
+    else
+      self.body:applyTorque(self.turnMultiplier * inertia)
+    end
+  end
+
+  if self.isreversing then
     fx = mass * self.acceleration * math.cos(angle)
     fy = mass * self.acceleration * math.sin(angle)
     self.body:applyForce(fx, fy)
@@ -123,6 +134,50 @@ function rotateVector(x, y, angle)
   s = math.sin(angle)
   c = math.cos(angle)
   return x*c - y*s, x*s + y*c
+end
+
+function player:beginAccelerate()
+  self.isaccelerating = true
+  self.isreversing = false
+end
+
+function player:beginBrake()
+  self.isbraking = true
+end
+
+function player:beginReversing()
+  self.isaccelerating = false
+  self.isreversing = true
+end
+
+function player:beginTurningLeft()
+  self.isturningleft = true
+  self.isturningright = false
+end
+
+function player:beginTurningRight()
+  self.isturningleft = false
+  self.isturningright = true
+end
+
+function player:endAccelerate()
+  self.isaccelerating = false
+end
+
+function player:endBrake()
+  self.isbraking = false
+end
+
+function player:endReversing()
+  self.isreversing = false
+end
+
+function player:endTurningLeft()
+  self.isturningleft = false
+end
+
+function player:endTurningRight()
+  self.isturningright = false
 end
 
 return player

--- a/src/entities/player.lua
+++ b/src/entities/player.lua
@@ -138,7 +138,6 @@ end
 
 function player:beginAccelerate()
   self.isaccelerating = true
-  self.isreversing = false
 end
 
 function player:beginBrake()
@@ -146,17 +145,14 @@ function player:beginBrake()
 end
 
 function player:beginReversing()
-  self.isaccelerating = false
   self.isreversing = true
 end
 
 function player:beginTurningLeft()
   self.isturningleft = true
-  self.isturningright = false
 end
 
 function player:beginTurningRight()
-  self.isturningleft = false
   self.isturningright = true
 end
 

--- a/src/main.lua
+++ b/src/main.lua
@@ -166,3 +166,31 @@ end
 function love.filedropped(file)
   player.img = love.graphics.newImage(file)
 end
+
+function love.keypressed(key, scancode, isrepeat)
+  if key == "w" then
+    player:beginAccelerate()
+  elseif key == "s" then
+    player:beginReversing()
+  elseif key == "a" then
+    player:beginTurningLeft()
+  elseif key == "d" then
+    player:beginTurningRight()
+  elseif key == " " then
+    player:beginBraking()
+  end
+end
+
+function love.keyreleased(key, scancode)
+  if key == "w" then
+    player:endAccelerate()
+  elseif key == "s" then
+    player:endReversing()
+  elseif key == "a" then
+    player:endTurningLeft()
+  elseif key == "d" then
+    player:endTurningRight()
+  elseif key == " " then
+    player:endBraking()
+  end
+end


### PR DESCRIPTION
Really rough version to decouple the keypresses from the `player:update` callback.

Still need to work on getting turning to actually turn when acceleration is not being directly applied.