### PR TITLE
Set up road paving to be passed through the netMan

### DIFF
--- a/src/entities/road.lua
+++ b/src/entities/road.lua
@@ -92,8 +92,8 @@ function road:update(newSegments)
   for _, s in ipairs(newSegments) do
   self:addSegment(s.x, s.y, s.angle)
   end
-  local i = table.getn(newSegments)
-  self:setFrontier(newSegments[i].x, newSegments[i].y, newSegments[i].angle, "center")
+  local lastSegment = newSegments[#newSegments]
+  self:setFrontier(lastSegment.x, lastSegment.y, lastSegment.angle, "center")
 end
 
 

--- a/src/entities/road.lua
+++ b/src/entities/road.lua
@@ -180,11 +180,11 @@ function road:setFrontier(x, y, angle, roadShift)
   -- center the frontier infront of the player.
   local deltaSlideX = nil
   local deltaSlideY = nil
-  local slideAngle = nil
   if roadShift == "center" then
     deltaSlideX = 0
     deltaSlideY = 0
   else
+    local slideAngle = nil
     if roadShift == "left" then
       slideAngle = leftAngle
     elseif roadShift == "right" then

--- a/src/entities/road.lua
+++ b/src/entities/road.lua
@@ -20,8 +20,8 @@ function road:load(x, y, width, length)
   self.roadPush = 1
   self.roadSlide = self.roadPush/5
   self.pivotLength = length * 0.6
-  sinLimit = (self.roadPush/2) / self.pivotLength
-  cosLimit = math.sqrt(self.pivotLength^2 - self.roadPush/2) / self.pivotLength
+  local sinLimit = (self.roadPush/2) / self.pivotLength
+  local cosLimit = math.sqrt(self.pivotLength^2 - self.roadPush/2) / self.pivotLength
   self.rotationLimit = math.pi - (math.abs(math.atan2(cosLimit, sinLimit)) * 2)
 
   -- the road is comprised of two major components: segments, which are a series
@@ -89,10 +89,10 @@ end
   
 function road:update(newSegments)
   -- create a road segment at the position and angle of the frontier.
-  for _, s in pairs(newSegments) do
+  for _, s in ipairs(newSegments) do
   self:addSegment(s.x, s.y, s.angle)
   end
-  i = table.getn(newSegments)
+  local i = table.getn(newSegments)
   self:setFrontier(newSegments[i].x, newSegments[i].y, newSegments[i].angle, "center")
 end
 
@@ -100,14 +100,14 @@ end
 -- utils
 
 function road:addSegment(x, y, angle)
-  segment = {}
+  local segment = {}
   segment.img = self.skin
   segment.width = segment.img:getWidth()
   segment.height = segment.img:getHeight()
   segment.body = love.physics.newBody(world)
   segment.body:setAngle(angle)
-  fx = math.sin(segment.body:getAngle()) * (segment.height/2)
-  fy = math.cos(segment.body:getAngle()) * -(segment.height/2)
+  local fx = math.sin(segment.body:getAngle()) * (segment.height/2)
+  local fy = math.cos(segment.body:getAngle()) * -(segment.height/2)
   segment.body:setX(x + fx)
   segment.body:setY(y + fy)
   segment.shape = love.physics.newRectangleShape(0, 0, segment.width, segment.height)
@@ -124,8 +124,8 @@ function road:pushFrontier(angle, roadShift)
   -- This can happen when crossing the pi/-pi theshold (e.g. the delta between
   -- angles 3 and -3)  If this happens so we adjust our angle so that we are
   -- within the range of values accepted.
-  lastAngle = self.frontier.main.body:getAngle()
-  deltaAngle = lastAngle - angle
+  local lastAngle = self.frontier.main.body:getAngle()
+  local deltaAngle = lastAngle - angle
   if math.abs(deltaAngle) > math.pi then
     if deltaAngle > 0 then
       deltaAngle = deltaAngle - 2 * math.pi
@@ -152,8 +152,8 @@ function road:pushFrontier(angle, roadShift)
 
   -- Get the old frontier position, and calculate the new position based on the
   -- new angle.
-  x = self.frontier.main.body:getX() + (self.roadPush) * math.cos(angle)
-  y = self.frontier.main.body:getY() + (self.roadPush) * math.sin(angle)
+  local x = self.frontier.main.body:getX() + (self.roadPush) * math.cos(angle)
+  local y = self.frontier.main.body:getY() + (self.roadPush) * math.sin(angle)
 
   self:setFrontier(x, y, angle, roadShift)
   return self.frontier.main.body:getX(), self.frontier.main.body:getY(), self.frontier.main.body:getAngle()
@@ -162,22 +162,25 @@ end
 function road:setFrontier(x, y, angle, roadShift)
   -- calculate positions of left and right frontiers relative to the new main
   -- frontier.
-  leftAngle = angle - (math.pi/2)
+  local leftAngle = angle - (math.pi/2)
   if leftAngle < -math.pi then
     leftAngle = leftAngle + 2 * math.pi
   end
-  deltaLeftX = self.frontier.main.length/3 * math.cos(leftAngle)
-  deltaLeftY = self.frontier.main.length/3 * math.sin(leftAngle)
-  rightAngle = angle + (math.pi/2)
+  local deltaLeftX = self.frontier.main.length/3 * math.cos(leftAngle)
+  local deltaLeftY = self.frontier.main.length/3 * math.sin(leftAngle)
+  local rightAngle = angle + (math.pi/2)
   if rightAngle > math.pi then
     rightAngle = rightAngle - 2 * math.pi
   end
-  deltaRightX = self.frontier.main.length/3 * math.cos(rightAngle)
-  deltaRightY = self.frontier.main.length/3 * math.sin(rightAngle)
+  local deltaRightX = self.frontier.main.length/3 * math.cos(rightAngle)
+  local deltaRightY = self.frontier.main.length/3 * math.sin(rightAngle)
   
   -- if the player is near the edge of the frontier, calculate deltaSlides,
   -- which shift the frontier perpendicular to the trajectory of the player to
   -- center the frontier infront of the player.
+  local deltaSlideX = nil
+  local deltaSlideY = nil
+  local slideAngle = nil
   if roadShift == "center" then
     deltaSlideX = 0
     deltaSlideY = 0

--- a/src/main.lua
+++ b/src/main.lua
@@ -171,11 +171,11 @@ function love.update(dt)
       local rightDistance = love.physics.getDistance(p.fixture, road.frontier.right.fixture)
       local roadShift
       if leftDistance < paveThreshold then
-        local roadShift = "left"
+        roadShift = "left"
       elseif rightDistance < paveThreshold then
-        local roadShift = "right"
+        roadShift = "right"
       else
-        local roadShift = "center"
+        roadShift = "center"
       end
       local x, y, angle = road:pushFrontier(p:getTrajectory(), roadShift)
       table.insert(newSegments, {x=x, y=y, angle=angle})

--- a/src/main.lua
+++ b/src/main.lua
@@ -165,29 +165,24 @@ function love.update(dt)
     local distance = love.physics.getDistance(p.fixture, road.frontier.main.fixture)
     -- collided with frontier
     local newSegments = {}
-    local i = 1
     while distance < paveThreshold do
       -- paving new road
       local leftDistance = love.physics.getDistance(p.fixture, road.frontier.left.fixture)
       local rightDistance = love.physics.getDistance(p.fixture, road.frontier.right.fixture)
       local roadShift
       if leftDistance < paveThreshold then
-        roadShift = "left"
+        local roadShift = "left"
       elseif rightDistance < paveThreshold then
-        roadShift = "right"
+        local roadShift = "right"
       else
-        roadShift = "center"
+        local roadShift = "center"
       end
-      x, y, angle = road:pushFrontier(p:getTrajectory(), roadShift)
-      newSegments[i] = {}
-      newSegments[i].x = x
-      newSegments[i].y = y
-      newSegments[i].angle = angle
-      i = i + 1
+      local x, y, angle = road:pushFrontier(p:getTrajectory(), roadShift)
+      table.insert(newSegments, {x=x, y=y, angle=angle})
       distance = love.physics.getDistance(p.fixture, road.frontier.main.fixture)
     end
     
-    if table.getn(newSegments) > 0 then
+    if #newSegments > 0 then
       road:update(newSegments)
     end
     

--- a/src/main.lua
+++ b/src/main.lua
@@ -164,6 +164,8 @@ function love.update(dt)
     -- detect if player is triggering new road creation and calculate location of new road
     local distance = love.physics.getDistance(p.fixture, road.frontier.main.fixture)
     -- collided with frontier
+    local newSegments = {}
+    local i = 1
     while distance < paveThreshold do
       -- paving new road
       local leftDistance = love.physics.getDistance(p.fixture, road.frontier.left.fixture)
@@ -176,10 +178,19 @@ function love.update(dt)
       else
         roadShift = "center"
       end
-      road:update(p:getTrajectory(), roadShift)
+      x, y, angle = road:pushFrontier(p:getTrajectory(), roadShift)
+      newSegments[i] = {}
+      newSegments[i].x = x
+      newSegments[i].y = y
+      newSegments[i].angle = angle
+      i = i + 1
       distance = love.physics.getDistance(p.fixture, road.frontier.main.fixture)
     end
-
+    
+    if table.getn(newSegments) > 0 then
+      road:update(newSegments)
+    end
+    
     netman:sendCoord(p)
   end
 


### PR DESCRIPTION
The goal here is to package all new road segments into a table before creating them all at once every trick. This will allow the netman to to take the new segments and broadcast them out to all the clients so that everyone is drawing the same new segments every tick.

`road:pushFrontier()` handles all the frontier transformations and returns the new frontier position (x,y,angle), which is added `to newSegments`. `road:update()` takes the table of new segments and iterates through it, creating all the segments locally. `road:update()` calls `road:setFrontier()` using the position of the last entry in `newSegments`.