### PR TITLE
Fix Braking Crash Bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Resolve issue causing game to crash when brake was released.
 
 ## [0.3.2] - 2019-03-01
 ### Added

--- a/src/entities/player.lua
+++ b/src/entities/player.lua
@@ -133,7 +133,7 @@ function player:create(x, y, id)
     return math.atan2(vy, vx)
   end
 
-  function p:beginAccelerate()
+  function p:beginAccelerating()
     self.isaccelerating = true
   end
 
@@ -153,7 +153,7 @@ function player:create(x, y, id)
     self.isturningright = true
   end
 
-  function p:endAccelerate()
+  function p:endAccelerating()
     self.isaccelerating = false
   end
 

--- a/src/entities/player.lua
+++ b/src/entities/player.lua
@@ -157,7 +157,7 @@ function player:create(x, y, id)
     self.isaccelerating = false
   end
 
-  function p:endBrake()
+  function p:endBraking()
     self.isbraking = false
   end
 

--- a/src/main.lua
+++ b/src/main.lua
@@ -220,7 +220,7 @@ end
 
 function love.keypressed(key, scancode, isrepeat)
   if key == "w" then
-    playerLocal:beginAccelerate()
+    playerLocal:beginAccelerating()
   elseif key == "s" then
     playerLocal:beginReversing()
   elseif key == "a" then
@@ -234,7 +234,7 @@ end
 
 function love.keyreleased(key, scancode)
   if key == "w" then
-    playerLocal:endAccelerate()
+    playerLocal:endAccelerating()
   elseif key == "s" then
     playerLocal:endReversing()
   elseif key == "a" then


### PR DESCRIPTION
Resolve issue causing the game to crash when brake (space) was released due to incorrect function name.

Rename `beginAccelerate -> beginAccelerating` because it was bothering me that all the others had `ing` 💅
