### PR TITLE
send road data over network

### DIFF
--- a/src/entities/player.lua
+++ b/src/entities/player.lua
@@ -1,4 +1,5 @@
 local assets = require("assets")
+local netman = require("net.netman")
 local base = require('entities.base')
 
 local player = {}
@@ -111,6 +112,8 @@ function player:create(x, y, id)
 
     local vx, vy = self.body:getLinearVelocity()
     self.speed = math.sqrt((vx * vx) + (vy * vy))
+
+    netman:sendCoord(self)
   end
 
   function p:draw()

--- a/src/main.lua
+++ b/src/main.lua
@@ -93,7 +93,7 @@ function love.handlers.netmanPlayerJoinRequest(id)
   for id, p in pairs(playersById) do
     coordsById[id] = p:getCoord()
   end
-  netman:welcome(id, coordsById)
+  netman:welcome(id, coordsById, road:getSegmentsData())
 end
 
 -- client handlers
@@ -160,33 +160,16 @@ function love.update(dt)
 
   for _, p in pairs(playersById) do
     p:update(ground, dt)
+    if isServer then
+      local segmentsData = road:pushFrontier(p)
+      netman:sendRoadData(segmentsData)
+    end
+  end
 
-    -- detect if player is triggering new road creation and calculate location of new road
-    local distance = love.physics.getDistance(p.fixture, road.frontier.main.fixture)
-    -- collided with frontier
-    local newSegments = {}
-    while distance < paveThreshold do
-      -- paving new road
-      local leftDistance = love.physics.getDistance(p.fixture, road.frontier.left.fixture)
-      local rightDistance = love.physics.getDistance(p.fixture, road.frontier.right.fixture)
-      local roadShift
-      if leftDistance < paveThreshold then
-        roadShift = "left"
-      elseif rightDistance < paveThreshold then
-        roadShift = "right"
-      else
-        roadShift = "center"
-      end
-      local x, y, angle = road:pushFrontier(p:getTrajectory(), roadShift)
-      table.insert(newSegments, {x=x, y=y, angle=angle})
-      distance = love.physics.getDistance(p.fixture, road.frontier.main.fixture)
-    end
-    
-    if #newSegments > 0 then
-      road:update(newSegments)
-    end
-    
-    netman:sendCoord(p)
+  if not isServer then -- client
+    local frontierData, segmentsData = netman:recvRoadData()
+    road:setFrontier(frontierData)
+    road:addSegments(segmentsData)
   end
 
   camera:setPosition(playerLocal:getPosition())

--- a/src/net/netman.lua
+++ b/src/net/netman.lua
@@ -17,10 +17,14 @@ netman.CMD_STOP = 7
 
 -- types of data we can request to send
 netman.SEND_COORD = 1
+netman.SEND_ROAD = 2
 
 -- disconnect reasons
 netman.DISCONNECT_LEFT = 0
 netman.DISCONNECT_BAD_VERSION = 1
+
+-- named channel names
+netman.CHAN_RECV_SEGMENTS = 'recvSegmentsDataChan'
 
 local cmdChan = nil -- command channel
 local sendChan = nil -- outgoing data channel
@@ -51,6 +55,14 @@ function netman:sendCoord(entity)
   sendChan:push(data)
 end
 
+function netman:sendRoadData(segmentsData)
+  if not segmentsData then
+    return
+  end
+  local data = {type=self.SEND_ROAD, segmentsData=segmentsData}
+  sendChan:push(data)
+end
+
 -- client commands
 function netman:connect(host, port)
   local cmd = {type=self.CMD_CONNECT, host=host, port=port}
@@ -67,9 +79,30 @@ function netman:leave(id)
   cmdChan:push(cmd)
 end
 
+function netman:recvRoadData()
+  local chan = love.thread.getChannel(self.CHAN_RECV_SEGMENTS)
+  local segmentsData = chan:pop()
+  if not segmentsData then
+    return
+  end
+
+  -- drain all segments we've received so far
+  local nextSegmentsData = chan:pop()
+  while nextSegmentsData do
+    for _, s in ipairs(nextSegmentsData) do
+      table.insert(segmentsData, s)
+    end
+    nextSegmentsData = chan:pop()
+  end
+
+  -- the frontier is the most recent segment
+  return segmentsData[#segmentsData], segmentsData
+end
+
 -- server commands
-function netman:welcome(id, coordsById)
-  local cmd = {type=self.CMD_WELCOME, id=id, coordsById=coordsById}
+function netman:welcome(id, coordsById, segmentsData)
+  local cmd = {type=self.CMD_WELCOME, id=id, coordsById=coordsById,
+               segmentsData=segmentsData}
   cmdChan:push(cmd)
 end
 

--- a/src/net/proto.lua
+++ b/src/net/proto.lua
@@ -6,7 +6,7 @@ local serpent = require("serpent.serpent")
 local proto = {}
 
 -- increment the version whenever the proto changes
-local VERSION = 2
+local VERSION = 3
 
 -- types of commands
 local PROTOCMD_JOIN = 1 -- join the server
@@ -31,6 +31,7 @@ local function allocSendData()
   local data = {
     cmd=PROTOCMD_SEND,
     coordsById={},
+    segmentsData={},
   }
   return data
 end
@@ -94,7 +95,7 @@ function proto:serverDisconnected(server)
   joinedPeers[server] = nil
 end
 
-function proto:welcome(id, coordsById)
+function proto:welcome(id, coordsById, segmentsData)
   local client = clientsById[id]
   if not client then
     logger:error("could not find connection for player %s", id)
@@ -103,7 +104,7 @@ function proto:welcome(id, coordsById)
   joinedPeers[client] = true
   love.event.push('netmanPlayerJoined', id)
   local data = {cmd=PROTOCMD_WELCOME, id=id, coordsById=coordsById,
-                text="welcome to the server!"}
+                segmentsData=segmentsData, text="welcome to the server!"}
   local msg = msgFromData(data)
   client:send(msg)
 end
@@ -135,6 +136,10 @@ function proto:prepare(peer, data)
   if data.type == netman.SEND_COORD then
     -- we only care about the most recent coord; overwrite whatever is here
     sendData.coordsById[data.id] = data.coord
+  elseif data.type == netman.SEND_ROAD then
+    for _, s in ipairs(data.segmentsData) do
+      table.insert(sendData.segmentsData, s)
+    end
   else
     logger:fatal("unrecognized send request type: %s", data.type)
   end
@@ -195,6 +200,7 @@ function proto:recv(peer, msg)
     for id, coord in pairs(data.coordsById) do
       love.event.push('netmanPlayerJoined', id, coord)
     end
+    love.thread.getChannel(netman.CHAN_RECV_SEGMENTS):push(data.segmentsData)
   elseif data.cmd == PROTOCMD_REJECT then
     love.event.push('netmanRejected', data.id, data.text)
   elseif data.cmd == PROTOCMD_ANNOUNCE_PLAYER_JOINED then
@@ -205,6 +211,7 @@ function proto:recv(peer, msg)
     for id, coord in pairs(data.coordsById) do
       love.event.push('netmanRecvCoord', id, coord)
     end
+    love.thread.getChannel(netman.CHAN_RECV_SEGMENTS):push(data.segmentsData)
   else
     logger:error("unsupported proto cmd: %d", data.cmd)
   end

--- a/src/net/server.lua
+++ b/src/net/server.lua
@@ -36,7 +36,7 @@ while true do
   local cmd = cmdChan:pop()
   while cmd do
     if cmd.type == netman.CMD_WELCOME then
-      proto:welcome(cmd.id, cmd.coordsById)
+      proto:welcome(cmd.id, cmd.coordsById, cmd.segmentsData)
     elseif cmd.type == netman.CMD_ANNOUNCE_PLAYER_JOINED then
       proto:announcePlayerJoined(cmd.id, cmd.coord)
     elseif cmd.type == netman.CMD_ANNOUNCE_PLAYER_LEFT then


### PR DESCRIPTION
This patch makes a fundamental change to the way clients interact with
the frontier.  Now, only the server can decide what influences where
the frontier goes and which cars get to push it.  The server bundles up
the road data and broadcasts it to the clients whenever it changes.
Also, we now send the entire road history to new clients in the welcome
message so that they may draw a all the road they missed out on before
connecting.

I did a little more refactoring in the road module so that we can easily
apply the received road data using a list of segment coordinates.  Also,
the main update loop is now smaller.

To support sending road data, netman now has a SEND_ROAD send type.  The
server can send road data with netman:sendRoadData().  The proto will
return freshly received road data through a new channel that netman
manages.  Clients can get the road updates via netman:recvRoadData().