### PR TITLE
Immediately disconnect when quitting

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -253,3 +253,9 @@ function love.keyreleased(key, scancode)
     playerLocal:endBraking()
   end
 end
+
+function love.quit()
+  if not isServer then
+    netman:leave(playerLocal:getId())
+  end
+end

--- a/src/main.lua
+++ b/src/main.lua
@@ -255,7 +255,9 @@ function love.keyreleased(key, scancode)
 end
 
 function love.quit()
-  if not isServer then
+  if isServer then
+    netman:announceShutdown()
+  else
     netman:leave(playerLocal:getId())
   end
 end

--- a/src/net/netman.lua
+++ b/src/net/netman.lua
@@ -15,7 +15,8 @@ netman.CMD_ANNOUNCE_PLAYER_JOINED = 5
 netman.CMD_ANNOUNCE_PLAYER_LEFT = 6
 netman.CMD_ANNOUNCE_PLAYER_SPRITE = 7
 netman.CMD_SEND_PLAYER_SPRITE = 8
-netman.CMD_STOP = 9
+netman.CMD_ANNOUNCE_SHUTDOWN = 9
+netman.CMD_STOP = 10
 
 -- types of data we can request to send
 netman.SEND_COORD = 1
@@ -125,6 +126,10 @@ end
 
 function netman:announcePlayerSprite(id, sprite)
   local cmd = {type=self.CMD_ANNOUNCE_PLAYER_SPRITE, id=id, sprite=sprite}
+end
+
+function netman:announceShutdown()
+  local cmd = {type=self.CMD_ANNOUNCE_SHUTDOWN}
   cmdChan:push(cmd)
 end
 

--- a/src/net/server.lua
+++ b/src/net/server.lua
@@ -45,6 +45,8 @@ while true do
       proto:announcePlayerSprite(cmd.id, cmd.sprite)
     elseif cmd.type == netman.CMD_SEND_PLAYER_SPRITE then
       proto:sendPlayerSprite(cmd.id, cmd.sprite)
+    elseif cmd.type == netman.CMD_ANNOUNCE_SHUTDOWN then
+      proto:announceShutdown()
     elseif cmd.type == netman.CMD_STOP then
       goto exit
     else


### PR DESCRIPTION
Whenever a client game quits, it will now immediately inform the server that it is leaving. This removes and disconnects the client from all other peers immediately, instead of waiting for the client to time out before it is removed from the game.

Conversely, whenever a game hosting a server quits, it will broadcast a new "announce shutdown" command that forces each client to leave the (now defunct) server, immediately ending the multiplayer session instead of waiting for all peers to leave the server from timing out.